### PR TITLE
Formatting issue when using an examples table with more than 3 values

### DIFF
--- a/src/main/resources/group_stories.mustache
+++ b/src/main/resources/group_stories.mustache
@@ -41,7 +41,7 @@
                             </tr>
                             <tr id="{{stepsId}}" class="collapse example-steps {{summaryResult.bootstrapClass}}">
                                 <td></td>
-                                <td colspan="3">
+                                <td colspan="{{headers.size}}">
                                     {{#steps}}
                                         <span class="glyphicon glyphicon-{{result.bootstrapIcon}}"></span>&nbsp;{{{step}}}<br>
                                     {{/steps}}


### PR DESCRIPTION
The width is currently hardcoded to 3. This works fine for the examples in tests, but for use cases with more than 3 values in the examples table the format is not correct. Using the header size ensures the formatting is correct regardless of the number of values in the examples table.